### PR TITLE
Custom message types

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,13 +54,51 @@ public function livewireAction()
 }
 ```
 
-### Chaining
+### Message types
 
-- `flash('Message')->success()`: Set the flash theme to "success".
-- `flash('Message')->error()`: Set the flash theme to "danger".
-- `flash('Message')->warning()`: Set the flash theme to "warning".
-- `flash('Message')->notDismissable()`: Remove the close button on the flash message.
-- `flash('Message')->error()->notDismissable()`: Render a "danger" flash message that cannot be dismissed.
+Message types are defined in the `livewire-flash.php` config file, which can be published (see below) if desired. By default, there are four supported message types: `info` (default if nothing else is specified), `success`, `warning`, and `error`.
+
+To set a message's type, either:
+
+1. Pass it as the second argument to `flash()` - example: `flash('Your action succeeded', 'success')`, or
+2. Chain it as a method name fluently after `flash()` - example: `flash('Your action succeeded')->success()`
+
+Both of those will change the message's display (colors and icon) to the configured styles.
+
+### Customization
+
+To change the styles used by each message type, OR to add your own types, first publish the config file:
+
+```bash
+php artisan vendor:publish --provider="MattLibera\LivewireFlash\LivewireFlashServiceProvider"
+```
+
+Then, in the `styles` key you can change whatever you want:
+
+```php
+'styles' => [
+    'info' => [
+        'bg-color'     => 'bg-blue-100', // could change to bg-purple-100, or something.
+        'border-color' => 'border-blue-400',
+        'icon-color'   => 'text-blue-400',
+        'text-color'   => 'text-blue-800',
+        'icon'         => 'fas fa-info-circle', // could change to another FontAwesome icon
+    ],
+```
+
+Or you can add your own:
+
+```php
+'notice' => [
+    'bg-color'     => 'bg-orange-100',
+    'border-color' => 'border-orange-400',
+    'icon-color'   => 'text-orange-400',
+    'text-color'   => 'text-orange-800',
+    'icon'         => 'fas fa-flag',
+],
+```
+
+Whatever the case, just ensure that you call the alert by its config key: `flash('An important message')->notice()`
 
 ## Templates
 
@@ -74,26 +112,26 @@ There are also some sample alert components (styled using TailwindCSS) included 
 
 ### Customization
 
-The config file `livewire-flash.php` can be published by running:
+You can change the views that the Livewire components use for rendering, and the styles applied to each message type.
+
+> If you are not using TailwindCSS and/or FontAwesome, you should definitely do this to call your own alert component/partial to fit whatever your stack is using.
+
+First, publish the config file:
 
 ```bash
 php artisan vendor:publish --provider="MattLibera\LivewireFlash\LivewireFlashServiceProvider"
 ```
 
-Then, you can change the views that the Livewire components use for rendering, and the styles applied to each message type. If you are not using TailwindCSS and/or FontAwesome, you should customize that view to call your own alert component/partial to fit whatever your stack is using.
-
-If you ARE using TailwindCSS and FontAwesome, this config class can still be published to tweak the color classes and icon classes that are used for each message.
+Then, edit the `views` area:
 
 ```php
-'styles' => [
-    'info' => [
-        'bg-color'     => 'bg-blue-100', // could change to bg-purple-100, or something.
-        'border-color' => 'border-blue-400',
-        'icon-color'   => 'text-blue-400',
-        'text-color'   => 'text-blue-800',
-        'icon'         => 'fas fa-info-circle', // could change to another FontAwesome icon
-    ],
+'views' => [
+    'container' => 'livewire-flash::livewire.flash-container',
+    'message'   => 'partials.my-bootstrap-flash',
+],
 ```
+
+You can access the public message properties on `MattLibera\LivewireFlash\Message`, as well as `$styles` (which is injected via the Livewire component) in your template.
 
 ## Dismissable Messages
 
@@ -108,7 +146,7 @@ Multiple flash messages can be sent to the session:
 ```php
 // anywhere
 flash('Message 1');
-flash('Message 2')->important();
+flash('Message 2')->warning();
 
 return redirect('somewhere');
 ```
@@ -118,7 +156,7 @@ OR
 ```php
 // livewire component
 flash('Message 1')->livewire($this);
-flash('Message 2')->livewire($this);
+flash('Message 2')->warning()->livewire($this);
 ```
 
 However, at the moment, because of the way Livewire handles the session, you *cannot* mix-and-match... that is, you cannot do:
@@ -136,7 +174,10 @@ I am open to contributions to this package, and will do the best I can to mainta
 
 # Road Map
 
-- Ability to define more/custom alert types via config (tapping into `__call` on the Notifier class, probably)
+Some considerations for future versions:
+
+- Fluent options for setting an icon or colors on the fly
+- Modal for backward compatibility with original `laracasts/flash`
 
 # Credits and License
 

--- a/src/LivewireFlashNotifier.php
+++ b/src/LivewireFlashNotifier.php
@@ -35,50 +35,6 @@ class LivewireFlashNotifier
     }
 
     /**
-     * Flash an information message.
-     *
-     * @param  string|null $message
-     * @return $this
-     */
-    public function info($message = null)
-    {
-        return $this->message($message, 'info');
-    }
-
-    /**
-     * Flash a success message.
-     *
-     * @param  string|null $message
-     * @return $this
-     */
-    public function success($message = null)
-    {
-        return $this->message($message, 'success');
-    }
-
-    /**
-     * Flash an error message.
-     *
-     * @param  string|null $message
-     * @return $this
-     */
-    public function error($message = null)
-    {
-        return $this->message($message, 'danger');
-    }
-
-    /**
-     * Flash a warning message.
-     *
-     * @param  string|null $message
-     * @return $this
-     */
-    public function warning($message = null)
-    {
-        return $this->message($message, 'warning');
-    }
-
-    /**
      * Flash a general message.
      *
      * @param  string|null $message
@@ -170,7 +126,7 @@ class LivewireFlashNotifier
     }
 
     /**
-     * livewire
+     * Pop the last message off the stack and emit it to the Livewire component
      *
      * @param  Livewire\Component $livewire
      * @return \MattLibera\LivewireFlash\LivewireFlashNotifier
@@ -180,5 +136,21 @@ class LivewireFlashNotifier
         $livewire->emit('flashMessageAdded', $this->messages->pop());
 
         return $this;
+    }
+
+
+    /**
+     * Magic __call: pass the method name called as the message type if it is configured
+     *
+     * @param mixed $method
+     * @param mixed $arguments
+     * @return void
+     */
+    public function __call($method, $arguments)
+    {
+        $messageTypes = config('livewire-flash.styles');
+        if (isset($messageTypes[$method])) {
+            $this->message(null, $method);
+        }
     }
 }

--- a/src/publish/livewire-flash.php
+++ b/src/publish/livewire-flash.php
@@ -27,7 +27,7 @@ return [
             'text-color'   => 'text-yellow-800',
             'icon'         => 'fas fa-exclamation-circle',
         ],
-        'error' => [
+        'danger' => [
             'bg-color'     => 'bg-red-100',
             'border-color' => 'border-red-400',
             'icon-color'   => 'text-red-400',

--- a/src/publish/livewire-flash.php
+++ b/src/publish/livewire-flash.php
@@ -27,7 +27,7 @@ return [
             'text-color'   => 'text-yellow-800',
             'icon'         => 'fas fa-exclamation-circle',
         ],
-        'danger' => [
+        'error' => [
             'bg-color'     => 'bg-red-100',
             'border-color' => 'border-red-400',
             'icon-color'   => 'text-red-400',


### PR DESCRIPTION
Adds the ability to create custom message types in config, and makes use of `__call()` on the notifier class to set the type appropriately.

Also corrects the error / danger inconsistency, which is a Bootstrap convention. Since `error()` was the method name used by the original package, that was selected as the message style key. Can easily be overridden or duplicated by end-user if both 'error' and 'danger' need to be supported.