### PR TITLE
fix return type so that chaining works

### DIFF
--- a/src/LivewireFlashNotifier.php
+++ b/src/LivewireFlashNotifier.php
@@ -144,13 +144,13 @@ class LivewireFlashNotifier
      *
      * @param mixed $method
      * @param mixed $arguments
-     * @return void
+     * @return \MattLibera\LivewireFlash\LivewireFlashNotifier
      */
     public function __call($method, $arguments)
     {
         $messageTypes = config('livewire-flash.styles');
         if (isset($messageTypes[$method])) {
-            $this->message(null, $method);
+            return $this->message(null, $method);
         }
     }
 }


### PR DESCRIPTION
The previous move to magic `__call()` method works but breaks chaining, since it does not return the Flash Notifier class as the old methods used to. (#4) This PR fixes the issue by returning `$this->message()` instead of just calling it.