### PR TITLE
removes unneeded reference to an old Blade component registration (#8)

### DIFF
--- a/src/LivewireFlashServiceProvider.php
+++ b/src/LivewireFlashServiceProvider.php
@@ -48,7 +48,5 @@ class LivewireFlashServiceProvider extends ServiceProvider
 
         Livewire::component('flash-container', \MattLibera\LivewireFlash\Livewire\FlashContainer::class);
         Livewire::component('flash-message', \MattLibera\LivewireFlash\Livewire\FlashMessage::class);
-
-        \Blade::component('livewire-flash::alert', 'livewire-flash::alerts.base');
     }
 }


### PR DESCRIPTION
The `livewire-flash::alert` component is not used anymore since the move to config-based views. This commit removes that directive per #8 to keep the Service Provider class cleaner.