### PR TITLE
Add overlay flash functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+/.idea
 .DS_Store

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,13 @@ To set a message's type, either:
 
 Both of those will change the message's display (colors and icon) to the configured styles.
 
+### Overlay Message
+
+Overlay message is defined in the `livewire-flash.php` config file, which can be published (see below) if desired.
+
+To set an overlay message, chain the method name `overlay()` after `flash()`. When using overlay leave the `flash()` parameter empty. Enter your message as the first parameter and title as second parameter for `overlay()` - example: `flash()->overlay('Modal Message', 'Modal Title')`
+
+
 ### Customization
 
 To change the styles used by each message type, OR to add your own types, first publish the config file:
@@ -186,5 +193,6 @@ Credit for the original package goes to Jeffrey Way and Laracasts. Additional th
 * Caleb Porzio and his Livewire contributors for the awesome framework
 * Adam Wathan and the Tailwind crew
 * Taylor Otwell and co. for Laravel
+* Jeffery Way and his original Laracasts Flash package
 
 This is an MIT-licensed package. Please read license.md for the details.

--- a/src/Livewire/FlashOverlay.php
+++ b/src/Livewire/FlashOverlay.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace MattLibera\LivewireFlash\Livewire;
+
+use Livewire\Component;
+
+class FlashOverlay extends Component
+{
+    public $message;
+    public $styles = [];
+
+    public $shown = true;
+
+    public function mount($message)
+    {
+        if (!is_array($message)) {
+            $message = (array) $message;
+        }
+        $this->message = $message;
+        $this->styles = config('livewire-flash.styles.overlay');
+    }
+
+    public function render()
+    {
+        return view(config('livewire-flash.views.overlay'));
+    }
+
+    public function dismiss()
+    {
+        $this->shown = false;
+    }
+}

--- a/src/LivewireFlashNotifier.php
+++ b/src/LivewireFlashNotifier.php
@@ -72,6 +72,24 @@ class LivewireFlashNotifier
     }
 
     /**
+     * Flash an overlay modal.
+     *
+     * @param  string|null $message
+     * @param  string      $title
+     * @return $this
+     */
+    public function overlay($message = null, $title = null)
+    {
+        if (! $message) {
+            return $this->updateLastMessage(['title' => $title, 'overlay' => true]);
+        }
+
+        return $this->message(
+            new OverlayMessage(compact('title', 'message'))
+        );
+    }
+
+    /**
      * Add an "important" flash to the session.
      *
      * @return $this

--- a/src/LivewireFlashServiceProvider.php
+++ b/src/LivewireFlashServiceProvider.php
@@ -48,5 +48,6 @@ class LivewireFlashServiceProvider extends ServiceProvider
 
         Livewire::component('flash-container', \MattLibera\LivewireFlash\Livewire\FlashContainer::class);
         Livewire::component('flash-message', \MattLibera\LivewireFlash\Livewire\FlashMessage::class);
+        Livewire::component('flash-overlay', \MattLibera\LivewireFlash\Livewire\FlashOverlay::class);
     }
 }

--- a/src/Message.php
+++ b/src/Message.php
@@ -40,6 +40,13 @@ class Message implements \ArrayAccess
     public $dismissable = true;
 
     /**
+     * Whether the message is an overlay.
+     *
+     * @var bool
+     */
+    public $overlay = false;
+
+    /**
      * Create a new message instance.
      *
      * @param array $attributes
@@ -57,6 +64,8 @@ class Message implements \ArrayAccess
      */
     public function update($attributes = [])
     {
+        $attributes = array_filter($attributes);
+
         foreach ($attributes as $key => $attribute) {
             $this->$key = $attribute;
         }

--- a/src/OverlayMessage.php
+++ b/src/OverlayMessage.php
@@ -9,7 +9,7 @@ class OverlayMessage extends Message
      *
      * @var string
      */
-    public $title = 'Notice';
+    public $title = null;
 
     /**
      * Whether the message is an overlay.

--- a/src/publish/livewire-flash.php
+++ b/src/publish/livewire-flash.php
@@ -4,6 +4,7 @@ return [
     'views' => [
         'container' => 'livewire-flash::livewire.flash-container',
         'message'   => 'livewire-flash::livewire.flash-message',
+        'overlay'   => 'livewire-flash::livewire.flash-overlay',
     ],
     'styles' => [
         'info' => [
@@ -34,6 +35,25 @@ return [
             'text-color'   => 'text-red-800',
             'icon'         => 'fas fa-exclamation-triangle',
         ],
-    ],
+        'overlay' => [
+            'overly-bg-color' => 'bg-gray-500',
+            'overlay-bg-opacity' => 'opacity-75',
 
+            'title-text-color' => 'text-gray-900',
+
+            'body-text-color' => 'text-gray-500',
+
+            'button-border-color' => 'border-transparent',
+            'button-bg-color' => 'bg-indigo-600',
+            'button-text-color' => 'text-white',
+
+            'button-hover-bg-color' => 'hover:bg-indigo-700',
+            'button-hover-text-color' => 'hover:text-white',
+            'button-focus-ring-color' => 'focus:ring-indigo-500',
+
+            'button-extra-classes' => '',
+
+            'button-text' => 'Close',
+        ],
+    ],
 ];

--- a/src/views/livewire/flash-container.blade.php
+++ b/src/views/livewire/flash-container.blade.php
@@ -1,5 +1,9 @@
 <section>
 @foreach ($messages as $index => $message)
-    <livewire:flash-message :message="$message" :key="'lwfm_' . $index" />
+        @if ($message['overlay'])
+            <livewire:flash-overlay :message="$message" :key="'lwfo_' . $index" />
+        @else
+            <livewire:flash-message :message="$message" :key="'lwfm_' . $index" />
+        @endif
 @endforeach
 </section>

--- a/src/views/livewire/flash-overlay.blade.php
+++ b/src/views/livewire/flash-overlay.blade.php
@@ -1,0 +1,62 @@
+<div>
+    @if($shown)
+        <div class="fixed z-10 inset-0 overflow-y-auto">
+            <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+                <!--
+                  Background overlay, show/hide based on modal state.
+
+                  Entering: "ease-out duration-300"
+                    From: "opacity-0"
+                    To: "opacity-100"
+                  Leaving: "ease-in duration-200"
+                    From: "opacity-100"
+                    To: "opacity-0"
+                -->
+                <div class="fixed inset-0 transition-opacity" aria-hidden="true">
+                    <div class="absolute inset-0 {{ $styles['overly-bg-color'] }} {{ $styles['overlay-bg-opacity'] }}"></div>
+                </div>
+
+                <!-- This element is to trick the browser into centering the modal contents. -->
+                <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+                <!--
+                  Modal panel, show/hide based on modal state.
+
+                  Entering: "ease-out duration-300"
+                    From: "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+                    To: "opacity-100 translate-y-0 sm:scale-100"
+                  Leaving: "ease-in duration-200"
+                    From: "opacity-100 translate-y-0 sm:scale-100"
+                    To: "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+                -->
+                <div class="inline-block relative align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-sm sm:w-full sm:p-6" role="dialog" aria-modal="true" aria-labelledby="modal-headline">
+                    <div class="sm:block absolute top-0 right-0 pt-4 pr-4">
+                        <button wire:click="dismiss" type="button" class="text-gray-300 bg-white rounded-md text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                            <span class="sr-only">Close</span>
+                            <!-- Heroicon name: x -->
+                            <i class="fas fa-times"></i>
+                        </button>
+                    </div>
+                    <div>
+                        <div class="mt-3 text-center sm:mt-5">
+                            @if($message['title'])
+                                <h3 class="text-lg leading-6 font-medium {{ $styles['title-text-color'] }}" id="modal-headline">
+                                    {!! $message['title'] !!}
+                                </h3>
+                            @endif
+                            <div class="mt-2">
+                                <p class="text-sm {{ $styles['body-text-color'] }}">
+                                    {!! $message['message'] !!}
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="mt-5 sm:mt-6">
+                        <button wire:click="dismiss" type="button" class="inline-flex justify-center w-full rounded-md border {{ $styles['button-border-color'] }} shadow-sm px-4 py-2 {{ $styles['button-bg-color'] }} text-base font-medium {{ $styles['button-text-color'] }} {{ $styles['button-hover-bg-color'] }} {{ $styles['button-hover-text-color'] }} focus:outline-none focus:ring-2 focus:ring-offset-2 {{ $styles['button-focus-ring-color'] }} sm:text-sm {{ $styles['button-extra-classes'] }}">
+                            {{ $styles['button-text'] }}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    @endif
+</div>


### PR DESCRIPTION
Added in the similar functionality for overlay flash modals that was in the original Laracasts Flash. ie. `flash()->overlay('Modal Message', 'Modal Title')` I changed the title to not have a default of "Notice". This way if you do not enter a title for the modal, it will just not show one. The modal is built with tailwind. 