### PR TITLE
fix so that we can set dismissable to false

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -64,12 +64,9 @@ class Message implements \ArrayAccess
      */
     public function update($attributes = [])
     {
-        $attributes = array_filter($attributes);
-
         foreach ($attributes as $key => $attribute) {
             $this->$key = $attribute;
         }
-
         return $this;
     }
 


### PR DESCRIPTION
`array_filter` without a second argument will remove anything PHP deems to be `empty()`, and so setting `['dismissable' => false]` gets caught up in there and doesn't end up getting applied.

Removing this may have some side effects where extra attributes are present on the `Message` objects but I don't think it'll really have that much impact in the end.