### PR TITLE
Fix PHPUnit CVE: unsafe deserialization in PHPT coverage handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         "livewire/livewire": "^2.12.7|^3.6.4"
     },
     "require-dev": {
-        "mockery/mockery": "dev-master",
-        "phpunit/phpunit": "^6.1|^9.5.10|^10.5"
+        "mockery/mockery": "^1.6",
+        "phpunit/phpunit": "^10.5|^11.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary

- Bumps `phpunit/phpunit` from `^6.1|^9.5.10|^10.5` to `^10.5|^11.0` to resolve [Dependabot alert #4](https://github.com/mattlibera/livewire-flash/security/dependabot/4)
- `phpunit/phpunit < 8.5.52` is vulnerable to unsafe deserialization in PHPT code coverage handling; the old constraint allowed `^6.1` which falls in that range
- Also fixes `mockery/mockery` from the defunct `dev-master` to `^1.6` (the branch was renamed `dev-main`)

## Test plan

- [ ] `composer install` resolves without conflicts
- [ ] No PHPUnit versions below 10.5 are resolvable from the new constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)